### PR TITLE
(chore/feature): Markdown Linting + CVE Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,22 @@ What is Lightning?|Lightning ≈ Bitcoin|Revisting tx malleability|[SF Bitcoin D
 |Implementations|DotNetLightning|Incomplete implementation|[Lightning network daemon with F#](https://github.com/joemphilips/DotNetLightning) |
 |Implementations|geelightning|Incomplete implementation|[geelightning](https://gitlab.com/nblockchain/geelightning) in Rust |
 |Setting up a node||| [Bitcoin Lightning Network #1: Can I compile and run a node?](https://medium.com/andreas-tries-blockchain/bitcoin-lightning-network-1-can-i-compile-and-run-a-node-cd3138c68c15), [Beginner’s Guide to ️Lightning️ on a Raspberry Pi](https://github.com/Stadicus/guides/blob/master/raspibolt/README.md), [My Lightning Node setup with c-lightning](https://medium.com/coinmonks/my-lightning-node-setup-with-c-lightning-45bbb9993c0), [Fastest and cheapest way to get your own Lightning Node running - on a RaspberryPi with a nice LCD](https://github.com/rootzoll/raspiblitz) |
+|BOLTs|BOLT 1|Messaging|[The fascinating life of Lightning BOLT #1](https://twitter.com/rusty_twit/status/1166448340147421184) |
+|BOLTs|BOLT 2|Channels and HTLCs| [Opening and closing channels](https://twitter.com/rusty_twit/status/1168985274795343872), [HTLCs](https://twitter.com/rusty_twit/status/1171521859587674114) |
+|BOLTs|BOLT 3|Bitcoin Transactions|[Bitcoin Transactions](https://twitter.com/rusty_twit/status/1171884459001434112) |
+|BOLTs|BOLT 4|Onion Routing|[All things onion routing](https://twitter.com/rusty_twit/status/1174058046600777728) |
+|BOLTs|BOLT 5|Onchain|[Going onchain: the good, the bad, and the ugly](https://twitter.com/rusty_twit/status/1174421524024971264) |
+|BOLTs|BOLT 7|Gossip Network|[Gossip part 1](https://twitter.com/rusty_twit/status/1176594892459397120), [Gossip part 2](https://twitter.com/rusty_twit/status/1176958199078907906) |
+|BOLTs|BOLT 8|Transport| |
+|BOLTs|BOLT 9|LN Features| |
+|BOLTs|BOLT 10|DNS & Bootstrap| |
+|BOLTs|BOLT 11|Invoices & Payment Encoding| |
+
+## CVEs
+
+| Identifiers                        | Type  | Sources |
+|------------------------------------|-------|---------|
+|CVE-2019-12998 / CVE-2019-12999 / CVE-2019-13000|CVE Disclosure|[Full Disclosure](https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-September/002174.html), [Video Explanation](https://twitter.com/rusty_twit/status/1179131794538414080) |
 
 ### Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# What is this?
+# Lightning Network Curriculum
+
+## What Is This?
 
 While planning the [Chaincode Residency](https://residency.chaincode.com/), we put considerable effort into finding the best resources and creating a curriculum around Lightning protocol development.
 
@@ -7,10 +9,10 @@ Lightning is still a nascent technology, and so we expect maintenance of this do
 There are three portions to this curriculum:
 
 1. [Study Groups](https://github.com/chaincodelabs/study-groups#lightning) designed to provide bite-sized grouped subjects that you can either complete bookclub style or alone.
-2. [Seminar Videos](#seminar-videos) recorded during the Summer 2019 Chaincode Residency.
-3. [Lightning Syllabus](#lightning-syllabus) a collection of resources grouped by subjects.
+2. [Seminar Videos](##seminar-videos) recorded during the Summer 2019 Chaincode Residency.
+3. [Lightning Syllabus](##lightning-syllabus) a collection of resources grouped by subjects.
 
-# Seminar Videos
+## Seminar Videos
 
 | Session                                 | Topic                      | Link |
 |-----------------------------------------|----------------------------|------|
@@ -42,7 +44,7 @@ Privacy | Gossip protocol and privacy/How much do watchtowers need to know?/ Min
 | 1.1 and the far future | Rendezvous Routing | [https://youtu.be/Ms2WwRzBdkM](https://youtu.be/Ms2WwRzBdkM) |
 | 1.1 and the far future | Dual funded channels | [https://youtu.be/5wQUMtgsnPs](https://youtu.be/5wQUMtgsnPs) |
 
-# Lightning Syllabus
+## Lightning Syllabus
 
 | Subjects                        | Topics  | Sub-topics    | Sources |
 |---------------------------------|---------|---------------|---------|
@@ -128,6 +130,6 @@ What is Lightning?|Lightning ≈ Bitcoin|Revisting tx malleability|[SF Bitcoin D
 |Implementations|geelightning|Incomplete implementation|[geelightning](https://gitlab.com/nblockchain/geelightning) in Rust |
 |Setting up a node||| [Bitcoin Lightning Network #1: Can I compile and run a node?](https://medium.com/andreas-tries-blockchain/bitcoin-lightning-network-1-can-i-compile-and-run-a-node-cd3138c68c15), [Beginner’s Guide to ️Lightning️ on a Raspberry Pi](https://github.com/Stadicus/guides/blob/master/raspibolt/README.md), [My Lightning Node setup with c-lightning](https://medium.com/coinmonks/my-lightning-node-setup-with-c-lightning-45bbb9993c0), [Fastest and cheapest way to get your own Lightning Node running - on a RaspberryPi with a nice LCD](https://github.com/rootzoll/raspiblitz) |
 
-## Acknowledgements
+### Acknowledgements
 
 Special thanks to [Fabian Jahr](https://github.com/fjahr), [Christian Decker](https://github.com/cdecker), [Fabrice Drouin](https://github.com/sstone), [René Pickhardt](https://github.com/renepickhardt), and [Alex Bosworth](https://github.com/alexbosworth) for their help in putting together the above resources.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ While planning the [Chaincode Residency](https://residency.chaincode.com/), we p
 Lightning is still a nascent technology, and so we expect maintenance of this document to be an ongoing task. We could use your help. Please **consider opening a pull-request** to keep this document relevant.
 
 There are three portions to this curriculum:
+
 1. [Study Groups](https://github.com/chaincodelabs/study-groups#lightning) designed to provide bite-sized grouped subjects that you can either complete bookclub style or alone.
 2. [Seminar Videos](#seminar-videos) recorded during the Summer 2019 Chaincode Residency.
 3. [Lightning Syllabus](#lightning-syllabus) a collection of resources grouped by subjects.

--- a/README.md
+++ b/README.md
@@ -129,16 +129,6 @@ What is Lightning?|Lightning ≈ Bitcoin|Revisting tx malleability|[SF Bitcoin D
 |Implementations|DotNetLightning|Incomplete implementation|[Lightning network daemon with F#](https://github.com/joemphilips/DotNetLightning) |
 |Implementations|geelightning|Incomplete implementation|[geelightning](https://gitlab.com/nblockchain/geelightning) in Rust |
 |Setting up a node||| [Bitcoin Lightning Network #1: Can I compile and run a node?](https://medium.com/andreas-tries-blockchain/bitcoin-lightning-network-1-can-i-compile-and-run-a-node-cd3138c68c15), [Beginner’s Guide to ️Lightning️ on a Raspberry Pi](https://github.com/Stadicus/guides/blob/master/raspibolt/README.md), [My Lightning Node setup with c-lightning](https://medium.com/coinmonks/my-lightning-node-setup-with-c-lightning-45bbb9993c0), [Fastest and cheapest way to get your own Lightning Node running - on a RaspberryPi with a nice LCD](https://github.com/rootzoll/raspiblitz) |
-|BOLTs|BOLT 1|Messaging|[The fascinating life of Lightning BOLT #1](https://twitter.com/rusty_twit/status/1166448340147421184) |
-|BOLTs|BOLT 2|Channels and HTLCs| [Opening and closing channels](https://twitter.com/rusty_twit/status/1168985274795343872), [HTLCs](https://twitter.com/rusty_twit/status/1171521859587674114) |
-|BOLTs|BOLT 3|Bitcoin Transactions|[Bitcoin Transactions](https://twitter.com/rusty_twit/status/1171884459001434112) |
-|BOLTs|BOLT 4|Onion Routing|[All things onion routing](https://twitter.com/rusty_twit/status/1174058046600777728) |
-|BOLTs|BOLT 5|Onchain|[Going onchain: the good, the bad, and the ugly](https://twitter.com/rusty_twit/status/1174421524024971264) |
-|BOLTs|BOLT 7|Gossip Network|[Gossip part 1](https://twitter.com/rusty_twit/status/1176594892459397120), [Gossip part 2](https://twitter.com/rusty_twit/status/1176958199078907906) |
-|BOLTs|BOLT 8|Transport| |
-|BOLTs|BOLT 9|LN Features| |
-|BOLTs|BOLT 10|DNS & Bootstrap| |
-|BOLTs|BOLT 11|Invoices & Payment Encoding| |
 
 ## CVEs
 

--- a/README.md
+++ b/README.md
@@ -10,38 +10,37 @@ There are three portions to this curriculum:
 2. [Seminar Videos](#seminar-videos) recorded during the Summer 2019 Chaincode Residency.
 3. [Lightning Syllabus](#lightning-syllabus) a collection of resources grouped by subjects.
 
-
 # Seminar Videos
 
 | Session                                 | Topic                      | Link |
 |-----------------------------------------|----------------------------|------|
-| How pieces fit together | Overall picture | https://youtu.be/krux2v0jt4E |
-| How pieces fit together | Update | https://youtu.be/SoFlRCNdqDg |
-| How pieces fit together | Transfer | https://youtu.be/CGE8I8L7BAc |
-| How pieces fit together | Multihop | https://youtu.be/P7I-C0_sijg |
-| How pieces fit together | And the others that are worth mentioning but not exploring (base and transport) | https://youtu.be/wyri7cc83kQ |
-| Update layer | Trampoline Payments | https://youtu.be/1WmIjHrjFsg |
-| Update layer | Eltoo and the Far Future | https://youtu.be/3ZjymCOmn_A |
-| Onion Routing | Atomic multi-path payments (AMP) | https://youtu.be/Og4TGERPZMY |
-| Onion Routing | Keysend (formally known as spontaneous payments) | https://youtu.be/zaBY9_eEQWE |
-| Update layer - limitations | Fee management | https://youtu.be/r8S3iELg9_U |
-| Onion Routing | Deep Dive | https://youtu.be/D4kX0gR-H0Y |
-| Update layer - limitations | Incentive problems in the network | https://youtu.be/lByQUr7zPr0 |
-| Onion Routing- limitations | Routing failures | https://youtu.be/z5vEyvc2vrE |
-| Update layer | Gossip Protocol/Path Finding | https://youtu.be/MeEFUaRnMak |
-| Limitations | Payment UX | https://youtu.be/rVgAHMgMCzk |
-| Limitations | Limitations of lightweight clients | https://youtu.be/ULVItljEiFE |
-| Limitations | Running Lightning in Production | https://youtu.be/fhmeNWczeUg |
-| Limitations | Failure modes in action | https://github.com/sstone/ln-in-action|
-| | Submarine swaps/ Loops | https://youtu.be/qixhNBIHDyE |
-| Attack vectors | Attack vector intro | https://youtu.be/R5cSrftd8nc |
-Privacy | Gossip protocol and privacy/How much do watchtowers need to know?/ Minimizing what is broadcasted to the base layer |  https://gist.github.com/adamjonas/8da156886ffa414541eaa43c0c5074ca |
-| Privacy | Channel probing attack for channel balance | https://youtu.be/A7rp7bLbZoo, https://github.com/wbobeirne/channel-probing-attack|
-| 1.1 and the far future | Network Topology creation/maintenance | https://youtu.be/N7rlHCnaBf8 |
-| 1.1 and the far future | Splicing | https://youtu.be/ZzSveBMtUGI |
-| 1.1 and the far future | Multi-party channels/Channel factories | https://youtu.be/PUDWGH_MvmQ |
-| 1.1 and the far future | Rendezvous Routing | https://youtu.be/Ms2WwRzBdkM |
-| 1.1 and the far future | Dual funded channels | https://youtu.be/5wQUMtgsnPs |
+| How pieces fit together | Overall picture | [https://youtu.be/krux2v0jt4E](https://youtu.be/krux2v0jt4E) |
+| How pieces fit together | Update | [https://youtu.be/SoFlRCNdqDg](https://youtu.be/SoFlRCNdqDg) |
+| How pieces fit together | Transfer | [https://youtu.be/CGE8I8L7BAc](https://youtu.be/CGE8I8L7BAc) |
+| How pieces fit together | Multihop | [https://youtu.be/P7I-C0_sijg](https://youtu.be/P7I-C0_sijg) |
+| How pieces fit together | And the others that are worth mentioning but not exploring (base and transport) | [https://youtu.be/wyri7cc83kQ](https://youtu.be/wyri7cc83kQ) |
+| Update layer | Trampoline Payments | [https://youtu.be/1WmIjHrjFsg](https://youtu.be/1WmIjHrjFsg) |
+| Update layer | Eltoo and the Far Future | [https://youtu.be/3ZjymCOmn_A](https://youtu.be/3ZjymCOmn_A) |
+| Onion Routing | Atomic multi-path payments (AMP) | [https://youtu.be/Og4TGERPZMY](https://youtu.be/Og4TGERPZMY) |
+| Onion Routing | Keysend (formally known as spontaneous payments) | [https://youtu.be/zaBY9_eEQWE](https://youtu.be/zaBY9_eEQWE) |
+| Update layer - limitations | Fee management | [https://youtu.be/r8S3iELg9_U](https://youtu.be/r8S3iELg9_U) |
+| Onion Routing | Deep Dive | [https://youtu.be/D4kX0gR-H0Y](https://youtu.be/D4kX0gR-H0Y) |
+| Update layer - limitations | Incentive problems in the network | [https://youtu.be/lByQUr7zPr0](https://youtu.be/lByQUr7zPr0) |
+| Onion Routing- limitations | Routing failures | [https://youtu.be/z5vEyvc2vrE](https://youtu.be/z5vEyvc2vrE) |
+| Update layer | Gossip Protocol/Path Finding | [https://youtu.be/MeEFUaRnMak](https://youtu.be/MeEFUaRnMak) |
+| Limitations | Payment UX | [https://youtu.be/rVgAHMgMCzk](https://youtu.be/rVgAHMgMCzk) |
+| Limitations | Limitations of lightweight clients | [https://youtu.be/ULVItljEiFE](https://youtu.be/ULVItljEiFE) |
+| Limitations | Running Lightning in Production | [https://youtu.be/fhmeNWczeUg](https://youtu.be/fhmeNWczeUg) |
+| Limitations | Failure modes in action | [https://github.com/sstone/ln-in-action](https://github.com/sstone/ln-in-action) |
+| | Submarine swaps/ Loops | [https://youtu.be/qixhNBIHDyE](https://youtu.be/qixhNBIHDyE) |
+| Attack vectors | Attack vector intro | [https://youtu.be/R5cSrftd8nc](https://youtu.be/R5cSrftd8nc) |
+Privacy | Gossip protocol and privacy/How much do watchtowers need to know?/ Minimizing what is broadcasted to the base layer |  [https://gist.github.com/adamjonas/8da156886ffa414541eaa43c0c5074ca](https://gist.github.com/adamjonas/8da156886ffa414541eaa43c0c5074ca) |
+| Privacy | Channel probing attack for channel balance | [https://youtu.be/A7rp7bLbZoo](https://youtu.be/A7rp7bLbZoo), [https://github.com/wbobeirne/channel-probing-attack](https://github.com/wbobeirne/channel-probing-attack) |
+| 1.1 and the far future | Network Topology creation/maintenance | [https://youtu.be/N7rlHCnaBf8](https://youtu.be/N7rlHCnaBf8) |
+| 1.1 and the far future | Splicing | [https://youtu.be/ZzSveBMtUGI](https://youtu.be/ZzSveBMtUGI) |
+| 1.1 and the far future | Multi-party channels/Channel factories | [https://youtu.be/PUDWGH_MvmQ](https://youtu.be/PUDWGH_MvmQ) |
+| 1.1 and the far future | Rendezvous Routing | [https://youtu.be/Ms2WwRzBdkM](https://youtu.be/Ms2WwRzBdkM) |
+| 1.1 and the far future | Dual funded channels | [https://youtu.be/5wQUMtgsnPs](https://youtu.be/5wQUMtgsnPs) |
 
 # Lightning Syllabus
 
@@ -128,7 +127,6 @@ What is Lightning?|Lightning ≈ Bitcoin|Revisting tx malleability|[SF Bitcoin D
 |Implementations|DotNetLightning|Incomplete implementation|[Lightning network daemon with F#](https://github.com/joemphilips/DotNetLightning) |
 |Implementations|geelightning|Incomplete implementation|[geelightning](https://gitlab.com/nblockchain/geelightning) in Rust |
 |Setting up a node||| [Bitcoin Lightning Network #1: Can I compile and run a node?](https://medium.com/andreas-tries-blockchain/bitcoin-lightning-network-1-can-i-compile-and-run-a-node-cd3138c68c15), [Beginner’s Guide to ️Lightning️ on a Raspberry Pi](https://github.com/Stadicus/guides/blob/master/raspibolt/README.md), [My Lightning Node setup with c-lightning](https://medium.com/coinmonks/my-lightning-node-setup-with-c-lightning-45bbb9993c0), [Fastest and cheapest way to get your own Lightning Node running - on a RaspberryPi with a nice LCD](https://github.com/rootzoll/raspiblitz) |
-
 
 ## Acknowledgements
 


### PR DESCRIPTION
## Tasks

* **chore**: fix MD032/blanks-around-lists -- lists should be surrounded by blank space
* **chore**: fix MD034/no-bare-urls -- althought GitHub may pick up the URLs and automatically link them, it is not proper Markdown to have bare URLs
* **chore**: solve MD025/single-title/single-h1 -- multiple top level headings in the same document breaks hierarchy of content
* **feature**: adding CVE information links and video details

## Notes
Fixed a few Markdown linting issues. Wasn't sure how to organize Rusty's video series -- whether to place them individually in the sections they relate to, or keep them as a `series` which you watch one after the other. For now I put them at the end of the list, but happy to discuss and move it elsewhere.

There are 4 BOLTs missing from his series so I'll add these as they become available.

I decided to add the CVE information and links as it can be relevant. Do we think it's bad practice to alert to the CVEs when folks are trying to learn about the technology? I believe it's important to highlight so everyone is aware of past disclosures. Again, wasn't sure where to place it -- make a new CVE.md file that would house all of the CVE related information, or just a simple table in the main README.md file. For now I chose the latter.

@adamjonas 





